### PR TITLE
Fix README config section reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ semver-plugin = { id = "io.github.kmbisset89.semver.plugin", version.ref = "semv
 
 ### Configuration
 
-Configure the plugin via the simVerConfig extension in your Gradle build script:
+Configure the plugin via the semVerConfig extension in your Gradle build script:
 
 ***I recommend storing these in local.properties and not in your build.gradle file. This will prevent your sensitive
 information from being checked into source control.***


### PR DESCRIPTION
## Summary
- correct name of configuration extension in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68409b13ae68832bae160de772b82474